### PR TITLE
Irminsule -> Irmin

### DIFF
--- a/_includes/frontpage/about-mugshots.html
+++ b/_includes/frontpage/about-mugshots.html
@@ -47,38 +47,6 @@
 </div>
 
 <div class="span2 profile">
-  <a href="http://www.cs.nott.ac.uk/~rmm">
-    <div class="image-wrap">
-      <div class="hover-wrap">
-        <span class="overlay-img"></span>
-        <span class="overlay-text-thumb">Signpost<br/>Lead</span>
-      </div>
-      <img src="images/mugshots/mort.png" alt="Mort">
-    </div>
-  </a>
-  <h5 class="profile-name">
-    <a href="http://www.cs.nott.ac.uk/~rmm">Richard M</a>
-  </h5>
-  <p class="profile-description"></p>
-</div>
-
-<div class="span2 profile">
-  <a href="http://gazagnaire.org">
-    <div class="image-wrap">
-      <div class="hover-wrap">
-        <span class="overlay-img"></span>
-        <span class="overlay-text-thumb">Irminsule<br/>Lead</span>
-      </div>
-      <img src="images/mugshots/tg.png" alt="Thomas">
-    </div>
-  </a>
-  <h5 class="profile-name">
-    <a href="http://gazagnaire.org">Thomas G</a>
-  </h5>
-  <p class="profile-description"></p>      
-</div>
-
-<div class="span2 profile">
   <a href="http://dave.recoil.org">
     <div class="image-wrap">
       <div class="hover-wrap">
@@ -92,6 +60,38 @@
     <a href="http://dave.recoil.org">David S</a>
   </h5>
   <p class="profile-description"></p>      
+</div>
+
+<div class="span2 profile">
+  <a href="http://gazagnaire.org">
+    <div class="image-wrap">
+      <div class="hover-wrap">
+        <span class="overlay-img"></span>
+        <span class="overlay-text-thumb">Irmin<br/>Lead</span>
+      </div>
+      <img src="images/mugshots/tg.png" alt="Thomas">
+    </div>
+  </a>
+  <h5 class="profile-name">
+    <a href="http://gazagnaire.org">Thomas G</a>
+  </h5>
+  <p class="profile-description"></p>      
+</div>
+
+<div class="span2 profile">
+  <a href="http://www.cs.nott.ac.uk/~rmm">
+    <div class="image-wrap">
+      <div class="hover-wrap">
+        <span class="overlay-img"></span>
+        <span class="overlay-text-thumb">Signpost<br/>Lead</span>
+      </div>
+      <img src="images/mugshots/mort.png" alt="Mort">
+    </div>
+  </a>
+  <h5 class="profile-name">
+    <a href="http://www.cs.nott.ac.uk/~rmm">Richard M</a>
+  </h5>
+  <p class="profile-description"></p>
 </div>
 
 <div class="span2 profile">

--- a/_includes/frontpage/sw-infra-intro.html
+++ b/_includes/frontpage/sw-infra-intro.html
@@ -8,7 +8,7 @@
     systems that anyone can build on. These tools are the bedrock on which 
     we will create the next generation of products. They deal with the 
     issues of 
-    <a href='#signpost'>connectivity</a>,
-    <a href='#irminsule'>synchronisation</a>, and 
-    <a href='#mirage'>deployment</a>.
+    <a href='#mirage'>deployment</a>,
+    <a href='#irmin'>synchronisation</a> and
+    <a href='#signpost'>connectivity</a>.
 </p>

--- a/_includes/frontpage/sw-infra.html
+++ b/_includes/frontpage/sw-infra.html
@@ -25,6 +25,29 @@
   <div class="span3">
     <div class="services-box">
       <div class="icon" style="margin-top: 5px;">
+        <a href="/software/irmin"><span class="icon-refresh"></span></a>
+      </div>
+    </div>   
+  </div>
+  <div class="span9">
+    <h3 id='irmin'>Irmin</h3>
+    <p>
+      Having multiple devices has made the engineering effort around data 
+      persistence and sync more complex. We have to concern ourselves about 
+      how data obtained for one device is made available and useful to 
+      others, without losing history. <strong>Irmin</strong> is a new 
+      kind of library database, based on the principles of Git (the version 
+      control system), meaning that all history can be kept and moved 
+      between devices with ease.<br />
+      <em>(<a href='/software/irmin/'>more about irmin</a></em>)
+    </p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="span3">
+    <div class="services-box">
+      <div class="icon" style="margin-top: 5px;">
         <a href="/software/signpost"><span class="icon-compass"></span></a>
       </div>
     </div>   
@@ -43,28 +66,3 @@
     </p>
   </div>
 </div>
-
-<div class="row">
-  <div class="span3">
-    <div class="services-box">
-      <div class="icon" style="margin-top: 5px;">
-        <a href="/software/irminsule"><span class="icon-refresh"></span></a>
-      </div>
-    </div>   
-  </div>
-  <div class="span9">
-    <h3 id='irminsule'>Irminsule</h3>
-    <p>
-      Having multiple devices has made the engineering effort around data 
-      persistence and sync more complex. We have to concern ourselves about 
-      how data obtained for one device is made available and useful to 
-      others, without losing history. <strong>Irminsule</strong> is a new 
-      kind of library database, based on the principles of Git (the version 
-      control system), meaning that all history can be kept and moved 
-      between devices with ease.<br />
-      <em>(<a href='/software/irminsule/'>more about irminsule</a></em>)
-    </p>
-  </div>
-</div>
-
-

--- a/_wip/old/about/index.md
+++ b/_wip/old/about/index.md
@@ -46,7 +46,7 @@ contributors so far.
 
 [![Thomas](/images/mugshots/tg.png)][thomas-www]  
 *[Thomas Gazagnaire][thomas-www]*  
-**Lead for [Irminsule](/software/irminsule)**  
+**Lead for [Irmin](/software/irmin)**  
 [thomas-www]: http://gazagnaire.org
 
 [![David](/images/mugshots/djs.jpg)][scotty-www]  

--- a/_wip/old/software-page.md
+++ b/_wip/old/software-page.md
@@ -27,7 +27,7 @@ The underlying building blocks are a crucial piece of the puzzle.  We need
 robust and open-source tools that allow us to create distributed systems 
 that anyone can build on.  These tools are the bedrock on which we will 
 create the next generation of products.  They deal with the issues of 
-[connectivity](#signpost), [synchronisation](#irminsule), and 
+[connectivity](#signpost), [synchronisation](#irmin), and 
 [deployment](#mirage).
 
 ### Signpost
@@ -40,16 +40,16 @@ any complex configuration.  Once all your devices can find each other,
 regardless of location, you effectively have your own little internet.  
 *([more about signpost](./signpost/)*)
 
-### Irminsule
+### Irmin
 
 <img style="float:right;"  src="/images/tree_of_digital_life-thumb.png">
 Having multiple devices has made the engineering effort around data 
 persistence and sync more complex.  We have to concern ourselves about how 
 data obtained for one device is made available and useful to others, without 
-losing history.  **Irminsule** is a new kind of library database, based on 
+losing history.  **Irmin** is a new kind of library database, based on 
 the principles of Git (the version control system), meaning that all history 
 can be kept and moved between devices with ease.  
-*([more about irminsule](./irminsule/)*)
+*([more about irmin](./irmin/)*)
 
 ### Mirage
 

--- a/blog/_posts/2013-09-02-introducing-nymote.md
+++ b/blog/_posts/2013-09-02-introducing-nymote.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Introducing Nymote"
 author: Amir Chaudhry
-tags: [infrastructure, internet of things, irminsule, mirage, signpost, tools]
+tags: [infrastructure, internet of things, irmin, mirage, signpost, tools]
 excerpt: "Nymote is a set of tools and software infrastructure, created from 
 the ground up, to provide end-users with life-long control of their networks 
 and personal data."
@@ -115,11 +115,11 @@ upgrade.
 <a href="http://www.flickr.com/photos/jezpage/4990873353/"><img style="float:right" src="/images/lego-blocks.jpg"></a>
 We're starting with fundamental [infrastructure][] to solve the problems 
 around [operating systems][Mirage] for the future, [identity][Signpost] for 
-users and devices and [data-persistence][Irminsule] across those devices.
+users and devices and [data-persistence][Irmin] across those devices.
 
 [Mirage]: /software/mirage
 [Signpost]: /software/signpost
-[Irminsule]: /software/irminsule
+[Irmin]: /software/irmin
 
 We began work on these issues four years ago under the umbrella of the 
 [Horizon Digital Economy programme][horizon-de], at Cambridge University and 
@@ -171,9 +171,9 @@ approach.
 [signposter1]: /docs/2012-signpost-poster-a4.pdf
 [signposter2]: /docs/2012-sigcomm-signposts-poster.pdf
 
-Finally, we will cover **[Irminsule][]**, which rethinks how we *persist data
+Finally, we will cover **[Irmin][]**, which rethinks how we *persist data
 * based on the principles of version control systems such as Git (or 
-historically, [Bayou][]).  Irminsule incorporates provenance and sync and 
+historically, [Bayou][]).  Irmin incorporates provenance and sync and 
 solves the problems of how all a user's devices coordinate and remain 
 synchronised with each other, and how that data is seamlessly backed up and 
 encrypted to prevent third-party snooping. This is increasingly important as 

--- a/blog/_posts/2013-09-12-indiewebcamp-uk.md
+++ b/blog/_posts/2013-09-12-indiewebcamp-uk.md
@@ -64,7 +64,7 @@ saw because it deals with some of the fundamental problems people need to
 solve.  For the case of Indie Web participants that meant dealing with 
 identity and authentication ([Signpost][]) as well as connectivity 
 ([Signpost][] again) and deployment ([Mirage][]).  We did briefly discuss 
-immutable datastores and sync problems, where [Irminsule][] is relevant. 
+immutable datastores and sync problems, where [Irmin][] is relevant. 
 I've collected some of these projects on a [links page][], which I'll be 
 adding to over time.  Please do [send me][email-link] any interesting things 
 which should go on that list.
@@ -93,7 +93,7 @@ Below are some quick notes I took during the sessions I attended.
 [HubMed]: http://www.hubmed.org
 [PubMed]: http://www.ncbi.nlm.nih.gov/pubmed
 [Mirage]: /software/mirage
-[Irminsule]: /software/irminsule
+[Irmin]: /software/irmin
 [links page]: /links
 [food-fest]: http://brightonfoodfestival.com
 [email-link]: mailto:amir@nymote.com?subject=New%20link%20to%20consider!

--- a/blog/_posts/2013-10-03-overview-of-mirage.md
+++ b/blog/_posts/2013-10-03-overview-of-mirage.md
@@ -115,7 +115,7 @@ short duration that they're needed.
 
 Overall, Mirage provides substantial benefits in terms of increased 
 efficiency and safety and is ideal for deploying to both the public could 
-and embedded devices.  Together with [Signpost][] and [Irminsule][], Mirage 
+and embedded devices.  Together with [Signpost][] and [Irmin][], Mirage 
 forms a core piece of the Nymote toolstack to power the coming wave of 
 [Internet of Things devices][iot-wiki].  
 
@@ -138,7 +138,7 @@ slides on the [Mirage page](/software/mirage).
 [mirage-www]: http://openmirage.org
 [RPi]: http://www.raspberrypi.org
 [Signpost]: /software/signpost
-[Irminsule]: /software/irminsule
+[Irmin]: /software/irmin
 [iot-wiki]: http://en.wikipedia.org/wiki/Internet_of_Things
 [horizon]: http://www.horizon.ac.uk
 [mirage-github]: http://github.com/mirage

--- a/blog/_posts/2014-01-13-announcing-first-mirage-release.md
+++ b/blog/_posts/2014-01-13-announcing-first-mirage-release.md
@@ -4,7 +4,7 @@ title: "Announcing the first major release of Mirage - the Cloud Operating Syste
 author: Amir Chaudhry and Anil Madhavapeddy
 date: 2014-01-13 17:00:00
 tags: [mirage, releases, software]
-excerpt: "We're very pleased to announce that version 1.0 of Mirage, the first of the components, has been released! This is the first major release of Mirage and represents many years of development, testing and community building. As mentioned previously, there are three main components of the Nymote toolstack, which are: Mirage - an operating system for the cloud, Signpost - an identity and connectivity system and Irminsule - a distributed database. As always, the best way to learn is to try things out, so follow the revamped install instructions and create your own webserver to host a static website!"
+excerpt: "We're very pleased to announce that version 1.0 of Mirage, the first of the components, has been released! This is the first major release of Mirage and represents many years of development, testing and community building. As mentioned previously, there are three main components of the Nymote toolstack, which are: Mirage - an operating system for the cloud, Signpost - an identity and connectivity system and Irmin - a distributed database. As always, the best way to learn is to try things out, so follow the revamped install instructions and create your own webserver to host a static website!"
 shorturl: http://nymote.org/blog/announcing-first-mirage-release
 ---
 {% include JB/setup %}
@@ -15,7 +15,7 @@ represents many years of development, testing and community building. As
 mentioned previously, there are three main components of the 
 [Nymote toolstack][nymote-intro], which are: [Mirage][mirage-nym] - an 
 operating system for the cloud, [Signpost][signpost-nym] - an identity and 
-connectivity system and [Irminsule][irmin-nym] - a distributed database. As 
+connectivity system and [Irmin][irmin-nym] - a distributed database. As 
 always, the best way to learn is to try things out, so follow the revamped 
 [install instructions][mirage-install] and create your own webserver to host 
 a static website!
@@ -67,7 +67,7 @@ will open up for us!
 [nymote-intro]: http://nymote.org/blog/2013/introducing-nymote/
 [mirage-nym]: http://nymote.org/software/mirage/
 [signpost-nym]: http://nymote.org/software/signpost/
-[irmin-nym]: http://nymote.org/software/irminsule/
+[irmin-nym]: http://nymote.org/software/irmin/
 [mirage-install]: http://openmirage.org/wiki/install
 [mirage-post]: http://nymote.org/blog/2013/overview-of-mirage/
 [mirage-www]: http://openmirage.org

--- a/blog/_posts/2014-01-30-heading-to-fosdem-2014.md
+++ b/blog/_posts/2014-01-30-heading-to-fosdem-2014.md
@@ -3,7 +3,7 @@ layout: post
 title: "Heading to FOSDEM!"
 author: Amir Chaudhry
 date: 2014-01-30 09:00:00
-tags: [conference, demo, irminsule, mirage]
+tags: [conference, demo, irmin, mirage]
 excerpt: "We're heading to FOSDEM in a few days!  If you haven't heard of FOSDEM before, it's a two-day, volunteer-organised event to promote open source software.  It takes place in Brussels and there will be over 500 talks, across 44 tracks attended by around 5000 people. The numbers alone don't capture the scale of the event so click though the image below for a view of the schedule -- and that's just for the Saturday. Did I mention this is all run by volunteers?"
 shorturl: http://bit.ly/MyEWP2
 ---

--- a/blog/_posts/2014-02-11-fosdem-summary.md
+++ b/blog/_posts/2014-02-11-fosdem-summary.md
@@ -3,7 +3,7 @@ layout: post
 title: "Summary of FOSDEM 2014"
 author: Amir Chaudhry
 date: 2014-02-11 13:40:00
-tags: [conference, demo, irminsule, mirage]
+tags: [conference, demo, irmin, mirage]
 excerpt: "It's been just over a week since FOSDEM ended and it was even more hectic than we imagined.  Thousands of open source developers across dozens of rooms and speakers and lots of delicious waffles.  I'm still in awe that this is a completely volunteer organised event and that everything appeared to run smoothly."
 shorturl: http://bit.ly/1fcKu8o
 ---

--- a/software/irmin/index.md
+++ b/software/irmin/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Irminsule
+title: Irmin
 tagline: "A branch-consistent 'git-like' database"
 next: "Create prototype for distributed queues"
 
@@ -13,7 +13,7 @@ next: "Create prototype for distributed queues"
 Having multiple devices has made the engineering effort around data 
 persistence and sync more complex.  We have to concern ourselves about how 
 data obtained for one device is made available and useful to others, without 
-losing history.  **Irminsule** is a new kind of library database, based on 
+losing history.  **Irmin** is a new kind of library database, based on 
 the principles of Git (the version control system), meaning that all history 
 can be kept and moved between devices with ease.
 
@@ -21,11 +21,13 @@ Many third-party services have arisen to tackle the specific issue of how
 our content remains synchronised across our devices. Yet most of them rely 
 on the premise of having one canonical location from which all other devices 
 take their cues.  This is invariably somewhere up in the cloud and is 
-subject to the whims of the providers.  Developers have had good distributed solutions that don't rely on one authority but why have such approaches not made it into more mainstream products?
+subject to the whims of the providers.  Developers have had good distributed
+solutions that don't rely on one authority but why have such approaches not
+made it into more mainstream products?
 
-**Irminsule** is a library database that takes the principles behind tools 
+**Irmin** is a library database that takes the principles behind tools 
 like Git and applies them to the wider problem of storing and syncing our 
-data.  This allows the possibility for all software using the Irminsule 
+data.  This allows the possibility for all software using the Irmin
 layer to remain in sync as changes can be pushed directly from one location 
 to another.  It also allows the possibility of reverting to previous 
 versions of any content as all history is also preserved.

--- a/software/irminsule/index.html
+++ b/software/irminsule/index.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; url=../irmin">


### PR DESCRIPTION
Replace all mentions of Irminsule with the new name of Irmin.
This will all be reworked for a new MISO site but it's worth
correcting it now.

Also reflow some of the content to match the acronym.

Closes #13
[skip ci]
